### PR TITLE
fix: cms check management command gives up when templates use {% with_data %} template tag

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,9 @@ Changelog
 unreleased
 ==========
 
+* Fix bug which let checks fail on templates using 
+  the with_data template tag. 
+
 4.0.0 2022-07-26
 ================
 

--- a/sekizai/helpers.py
+++ b/sekizai/helpers.py
@@ -87,12 +87,13 @@ def _extend_nodelist(extend_node):
 
 
 def _scan_namespaces(nodelist, current_block=None):
-    from sekizai.templatetags.sekizai_tags import RenderBlock
+    from sekizai.templatetags.sekizai_tags import RenderBlock, WithData
     found = []
-
+    print("SCAN")
     for node in nodelist:
+        print(node, type(node))
         # check if this is RenderBlock node
-        if isinstance(node, RenderBlock):
+        if isinstance(node, (RenderBlock, WithData)):
             # resolve it's name against a dummy context
             found.append(node.kwargs['name'].resolve({}))
             found += _scan_namespaces(node.blocks['nodelist'], node)

--- a/sekizai/helpers.py
+++ b/sekizai/helpers.py
@@ -89,9 +89,8 @@ def _extend_nodelist(extend_node):
 def _scan_namespaces(nodelist, current_block=None):
     from sekizai.templatetags.sekizai_tags import RenderBlock, WithData
     found = []
-    print("SCAN")
+
     for node in nodelist:
-        print(node, type(node))
         # check if this is RenderBlock node
         if isinstance(node, (RenderBlock, WithData)):
             # resolve it's name against a dummy context

--- a/tests/templates/with_data_basic.html
+++ b/tests/templates/with_data_basic.html
@@ -1,0 +1,25 @@
+{% load sekizai_tags %}<!DOCTYPE html>
+<html>
+  <head>
+    <title>{% block title %}{% block pagetitle %}{% endblock pagetitle %}{% endblock title %}</title>
+    {% with_data "google-fonts" as fonts %}{% if fonts %}
+    <link href="https://fonts.googleapis.com/css?family={{ fonts|join:',' }}" rel="stylesheet">
+    {% endif %}{% end_with_data %}
+    <!-- Compressed CSS -->
+    {% render_block "css" %}
+    <!-- Live CSS -->
+    {% block live_css %}{% endblock live_css %}
+    {% block head %}{% endblock head %}
+  </head>
+
+  <body>
+  <h1>Test page.</h1>
+  {% block breadcrumb %}{% endblock %}
+  {% block content %}
+    <p>This page intentionally left blank.</p>
+  {% endblock content %}
+  {% render_block "js" %}
+  {% block live_js %}{% endblock live_js %}
+  </body>
+</html>
+

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -379,6 +379,9 @@ class HelperTests(TestCase):
     def test_validate_template_js_css(self):
         self.assertTrue(validate_template('basic.html', ['js', 'css']))
 
+    def test_validate_template_with_data(self):
+        self.assertTrue(validate_template('with_data_basic.html', ['js', 'css']))
+
     def test_validate_template_js(self):
         self.assertTrue(validate_template('basic.html', ['js']))
 


### PR DESCRIPTION
This PR fixes #118 and https://github.com/django-cms/django-cms/issues/6911.

`./manage.py cms check` failed for sekizai if the cms templates use the `{% data_with %}` template tag.

The reason is that both `data_with` and `render_block` template tags need to render the remaining nodes of the template before being able to render the content (since `add_data` or `add_to_block` might add information). Therefore both use the `SekizaiParser` which stores the rest of the template unprocessed in a `nodelist`. Upon rendering the tag, the node list is processed first, then the tag is rendered and the node list just appended.

`_scan_namespaces` took care of this in case of `render_block` but not in case of `data_with`. This PR now adds both tags for the special treatment.