### PR TITLE
chore: Add Django 5.2 tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        django-version: ['3.2', '4.2', '5.0', '5.1']
+        django-version: ['3.2', '4.2', '5.0', '5.1', '5.2']
         os: [
           ubuntu-latest
         ]
@@ -17,6 +17,8 @@ jobs:
           - django-version: '5.0'
             python-version: '3.9'
           - django-version: '5.1'
+            python-version: '3.9'
+          - django-version: '5.2'
             python-version: '3.9'
           - django-version: '3.2'
             python-version: '3.13'

--- a/README.rst
+++ b/README.rst
@@ -72,5 +72,5 @@ You can run tests by executing::
 
 .. |python| image:: https://img.shields.io/badge/python-3.9+-blue.svg
     :target: https://pypi.org/project/django-sekizai/
-.. |django| image:: https://img.shields.io/badge/django-4.2,%205.0,%205.1-blue.svg
+.. |django| image:: https://img.shields.io/badge/django-4.2--5.2-blue.svg
     :target: https://www.djangoproject.com/


### PR DESCRIPTION
Django 5.2 has been released. This PR adds tests for it.

Fixes #184 

## Summary by Sourcery

Add support for testing with Django 5.2 in the project's CI workflow

CI:
- Update GitHub Actions workflow to include Django 5.2 in the test matrix

Tests:
- Extend test coverage to include Django 5.2 compatibility